### PR TITLE
Update UuidType.php

### DIFF
--- a/src/Shared/Infrastructure/Persistence/Doctrine/UuidType.php
+++ b/src/Shared/Infrastructure/Persistence/Doctrine/UuidType.php
@@ -35,6 +35,10 @@ abstract class UuidType extends StringType implements DoctrineCustomType
     /** @var Uuid $value */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        return $value->value();
+        if ($value instanceof Uuid) {
+            return $value->value();
+        }
+        
+        return $value === null ? null : (string) $value;
     }
 }


### PR DESCRIPTION
El método convertToDatabaseValue le viene como argumento $value que en algunas ocasiones puede ser un string o puede ser también una instancia de Uuid por ello llamamos al método value, aunque siempre tendrá que devolver un string