### PR TITLE
Fix php-amqp clone repository

### DIFF
--- a/etc/infrastructure/php/extensions/amqp.sh
+++ b/etc/infrastructure/php/extensions/amqp.sh
@@ -1,4 +1,4 @@
-git clone --branch issue-php8 https://github.com/remicollet/php-amqp.git
+git clone https://github.com/php-amqp/php-amqp.git
 cd php-amqp
 phpize
 ./configure


### PR DESCRIPTION
https://github.com/remicollet/php-amqp.git no longer has issue-php8 branch
Output:
```
git clone --branch issue-php8 https://github.com/remicollet/php-amqp.git
Cloning into 'php-amqp'...
fatal: Remote branch issue-php8 not found in upstream origin
```

So, I noticed that original repository now supports php 8. 
