### PR TITLE
Fix AMQP related errors while building the environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,28 @@ jobs:
 
       - run: docker-compose pull
 
-      - name: Install dependencies
+      - name: 🎻 Install dependencies
         run: make composer-install
 
-      - name: Start all the environment
+      - name: 🐳 Start all the environment
         run: make start
 
-      - name: Wait for the environment to get up
+      - name: 🏁 Static analysis
+        run: make static-analysis
+
+      - name: 🦭 Wait for the database to get up
         run: |
           while ! make ping-mysql &>/dev/null; do
               echo "Waiting for database connection..."
               sleep 2
           done
 
-      - name: Run the tests
-        run: make test
+      - name: 🐰 Wait for the message broker to get up
+        run: |
+          while ! make ping-rabbitmq &>/dev/null; do
+              echo "Waiting for RabbitMQ connection..."
+              sleep 2
+          done
 
-      - name: Static analysis
-        run: make static-analysis
+      - name: ✅ Run the tests
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,6 @@ jobs:
 
       - run: docker-compose pull
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: php_ddd_example-cache-${{ secrets.CACHE_VERSION }}-{hash}
-          restore-keys: |
-            php_ddd_example-cache-${{ secrets.CACHE_VERSION }}-
       - name: Install dependencies
         run: make composer-install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,11 @@ RUN apk --update upgrade \
         zip \
         pdo_mysql
 
-RUN pickle install apcu-5.1.20
+RUN pickle install apcu@5.1.20
+RUN pickle install amqp@1.11.0beta
 
-ADD etc/infrastructure/php/extensions/rabbitmq.sh /root/install-rabbitmq.sh
 ADD etc/infrastructure/php/extensions/xdebug.sh /root/install-xdebug.sh
 RUN apk add git
-RUN sh /root/install-rabbitmq.sh
 RUN sh /root/install-xdebug.sh
 
 RUN docker-php-ext-enable \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,11 @@ RUN apk --update upgrade \
         pdo_mysql
 
 RUN pickle install apcu@5.1.20
-RUN pickle install amqp@1.10.2
 
+ADD etc/infrastructure/php/extensions/rabbitmq.sh /root/install-rabbitmq.sh
 ADD etc/infrastructure/php/extensions/xdebug.sh /root/install-xdebug.sh
 RUN apk add git
+RUN sh /root/install-rabbitmq.sh
 RUN sh /root/install-xdebug.sh
 
 RUN docker-php-ext-enable \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk --update upgrade \
         pdo_mysql
 
 RUN pickle install apcu@5.1.20
-RUN pickle install amqp@1.11.0beta
+RUN pickle install amqp@1.10.2
 
 ADD etc/infrastructure/php/extensions/xdebug.sh /root/install-xdebug.sh
 RUN apk add git

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ rebuild: composer-env-file
 ping-mysql:
 	@docker exec codelytv-php_ddd_skeleton-mooc-mysql mysqladmin --user=root --password= --host "127.0.0.1" ping --silent
 
+.PHONY: ping-rabbitmq
+ping-rabbitmq:
+	@docker exec codelytv-php_ddd_skeleton-rabbitmq rabbitmqctl ping --silent
+
 clean-cache:
 	@rm -rf apps/*/*/var
 	@docker exec codelytv-php_ddd_skeleton-backoffice_backend-php ./apps/backoffice/backend/bin/console cache:warmup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   mooc_mysql:
     container_name: codelytv-php_ddd_skeleton-mooc-mysql
-    image: mysql:8.0
+    image: mariadb:10.6
     ports:
       - 3360:3306
     environment:

--- a/etc/infrastructure/php/extensions/rabbitmq.sh
+++ b/etc/infrastructure/php/extensions/rabbitmq.sh
@@ -1,0 +1,6 @@
+git clone https://github.com/php-amqp/php-amqp.git
+cd php-amqp
+phpize
+./configure
+make
+make install

--- a/etc/infrastructure/php/extensions/rabbitmq.sh
+++ b/etc/infrastructure/php/extensions/rabbitmq.sh
@@ -1,4 +1,4 @@
-git clone --depth 1 --branch v1.10.2 https://github.com/php-amqp/php-amqp.git
+git clone --depth 1 --branch v1.11.0beta https://github.com/php-amqp/php-amqp.git
 cd php-amqp
 phpize
 ./configure

--- a/etc/infrastructure/php/extensions/rabbitmq.sh
+++ b/etc/infrastructure/php/extensions/rabbitmq.sh
@@ -1,6 +1,0 @@
-git clone https://github.com/php-amqp/php-amqp.git
-cd php-amqp
-phpize
-./configure
-make
-make install

--- a/etc/infrastructure/php/extensions/rabbitmq.sh
+++ b/etc/infrastructure/php/extensions/rabbitmq.sh
@@ -1,4 +1,4 @@
-git clone https://github.com/php-amqp/php-amqp.git
+git clone --depth 1 --branch v1.10.2 https://github.com/php-amqp/php-amqp.git
 cd php-amqp
 phpize
 ./configure

--- a/etc/infrastructure/php/extensions/xdebug.sh
+++ b/etc/infrastructure/php/extensions/xdebug.sh
@@ -1,4 +1,4 @@
-git clone -n https://github.com/xdebug/xdebug.git
+git clone --depth 1 --branch 3.0.4 https://github.com/xdebug/xdebug.git
 cd xdebug
 git checkout 592ab9fa10cfa132623489511e92ef69fb91744c
 phpize


### PR DESCRIPTION
# Current progress

- [x] Apple Silicon compatibility: From MySQL to MariaDB because [MySQL image is not yet available for Apple Silicon](https://docs.docker.com/docker-for-mac/apple-silicon/#known-issues))
- [x] AMQP extension being able to compile and execute the GitHub Action Workflow tests

# Actions done

- We were using PHP in RC version → [https://github.com/CodelyTV/php-ddd-example/pull/254](https://github.com/CodelyTV/php-ddd-example/pull/254)
- We're using the PHP AMQP C extension [php-amqp](https://github.com/php-amqp/php-amqp) from where we should not get out in order to avoid loosing the performance gains that it has over the pure PHP implementation
- We were using the latest commit available on that extension: [https://github.com/CodelyTV/php-ddd-example/blob/master/etc/infrastructure/php/extensions/rabbitmq.sh](https://github.com/CodelyTV/php-ddd-example/blob/master/etc/infrastructure/php/extensions/rabbitmq.sh)
- [Pickle should be able to install any PECL extension](https://github.com/FriendsOfPHP/pickle/blob/master/README.md#L56-L60)
- The AMQP extension has new beta version released with PHP 8 support: [https://pecl.php.net/package/amqp](https://pecl.php.net/package/amqp)
- Pickle can not find the latest AMQP version (1.11.0beta): [Commit CI Workflow](https://github.com/CodelyTV/php-ddd-example/runs/2546159931)
- Pickle can not compile the latest stable AMQP version (1.10.2) [Commit CI workflow](https://github.com/CodelyTV/php-ddd-example/pull/253/checks?check_run_id=2546436845)
- Do not know why, but [it is still working in `master`](https://github.com/CodelyTV/php-ddd-example/runs/2545988817)
- Once removing the Docker cache GitHub Action:
    - Installing the stable `v1.10.2` tag, [it can not compile](https://github.com/CodelyTV/php-ddd-example/pull/253/checks?check_run_id=2546748036)
    - Installing the beta `v1.11.0beta` tag, [it can not find the AMQP host](https://github.com/CodelyTV/php-ddd-example/pull/253/checks?check_run_id=2546820468): `AMQPConnectionException: Socket error: could not connect to host`
    - Installing from the AMQP git `master` branch, [it can not find the AMQP host](https://github.com/CodelyTV/php-ddd-example/runs/2546677874): `AMQPConnectionException: Socket error: could not connect to host`
- [Add a health-check for the RabbitMQ host](https://github.com/CodelyTV/php-ddd-example/pull/253/commits/a2393ccfebb834647d2810ddbb7e6849e7bff478#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR35-R40) as [we already have for the database one](https://github.com/CodelyTV/php-ddd-example/blob/master/.github/workflows/ci.yml#L31-L36) before executing the tests and moving the static analysis up in the sequential workflow execution in order to gain some time

# Further work

- Once the AMQP `v1.11.0beta` version come out of beta and is available through Pickle, it would be awesome to remove the custom installation process.