### PR TITLE
make Video constructor private

### DIFF
--- a/src/Mooc/Videos/Domain/Video.php
+++ b/src/Mooc/Videos/Domain/Video.php
@@ -10,7 +10,7 @@ use CodelyTv\Shared\Domain\Aggregate\AggregateRoot;
 
 final class Video extends AggregateRoot
 {
-    public function __construct(
+    private function __construct(
         private VideoId $id,
         private VideoType $type,
         private VideoTitle $title,


### PR DESCRIPTION
If someone creates a Video through the constructor, the VideoCreatedDomainEvent will not be recorded to $domainEvents.
Or, the record of this event must be moved from the static create() method to the constructor.