### PR TITLE
fix: Run fpm as current host user instead of www-data #291

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ RUN docker-php-ext-enable \
         apcu \
         opcache
 
-RUN curl -sS https://get.symfony.com/cli/installer | bash && mv /root/.symfony/bin/symfony /usr/local/bin/symfony
+RUN curl -sS https://get.symfony.com/cli/installer | bash -s - --install-dir /usr/local/bin
 
 COPY etc/infrastructure/php/ /usr/local/etc/php/
+
+# allow non-root users have home
+RUN mkdir -p /opt/home
+RUN chmod 777 /opt/home
+ENV HOME /opt/home

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ composer-require-module: INTERACTIVE=-ti --interactive
 .PHONY: composer
 composer composer-install composer-update composer-require composer-require-module: composer-env-file
 	@docker run --rm $(INTERACTIVE) --volume $(current-dir):/app --user $(id -u):$(id -g) \
-		composer:2.2.6 $(CMD) \
+		composer:2.2 $(CMD) \
 			--ignore-platform-reqs \
 			--no-ansi
 
@@ -69,7 +69,7 @@ destroy: CMD=down
 # Usage: `make doco CMD="build --parallel --pull --force-rm --no-cache"`
 .PHONY: doco
 doco start stop destroy: composer-env-file
-	@docker-compose $(CMD)
+	UID=${shell id -u} GID=${shell id -g} docker-compose $(CMD)
 
 .PHONY: rebuild
 rebuild: composer-env-file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
 
   backoffice_backend_php:
     container_name: codelytv-php_ddd_skeleton-backoffice_backend-php
+    user: "${UID}:${GID}"
     build:
       context: .
       dockerfile: Dockerfile
@@ -70,6 +71,7 @@ services:
 
   backoffice_frontend_php:
     container_name: codelytv-php_ddd_skeleton-backoffice_frontend-php
+    user: "${UID}:${GID}"
     build:
       context: .
       dockerfile: Dockerfile
@@ -88,6 +90,7 @@ services:
 
   mooc_backend_php:
     container_name: codelytv-php_ddd_skeleton-mooc_backend-php
+    user: "${UID}:${GID}"
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This fixes #291

```shell
$ docker exec -it codelytv-php_ddd_skeleton-mooc_backend-php ps
PID   USER     TIME  COMMAND
    1 1000      0:00 symfony serve --dir=apps/mooc/backend/public --port=8030 -
   21 1000      0:00 php-fpm: master process (/.symfony/php/e6bff699f92947e5351
   22 1000      0:00 php-fpm: pool www
   23 1000      0:00 php-fpm: pool www
   33 1000      0:00 ps
```
