### PR TITLE
Use json_decode exception

### DIFF
--- a/src/Shared/Domain/Utils.php
+++ b/src/Shared/Domain/Utils.php
@@ -38,13 +38,7 @@ final class Utils
 
 	public static function jsonDecode(string $json): array
 	{
-		$data = json_decode($json, true);
-
-		if (json_last_error() !== JSON_ERROR_NONE) {
-			throw new RuntimeException('Unable to parse response body into JSON: ' . json_last_error());
-		}
-
-		return $data;
+		return json_decode($json, true, flags: JSON_THROW_ON_ERROR);
 	}
 
 	public static function toSnakeCase(string $text): string

--- a/src/Shared/Domain/Utils.php
+++ b/src/Shared/Domain/Utils.php
@@ -6,7 +6,6 @@ namespace CodelyTv\Shared\Domain;
 
 use DateTimeImmutable;
 use DateTimeInterface;
-use RuntimeException;
 use function Lambdish\Phunctional\filter;
 
 final class Utils


### PR DESCRIPTION
Ahora es más rápido.

Lo curioso es que si lo usan en el `jsonEncode()`.

Ejemplo en https://3v4l.org/QoeBs

Fix: #373