### PR TITLE
Remove endsWith() in Utils class

### DIFF
--- a/src/Shared/Domain/Utils.php
+++ b/src/Shared/Domain/Utils.php
@@ -11,16 +11,6 @@ use function Lambdish\Phunctional\filter;
 
 final class Utils
 {
-	public static function endsWith(string $needle, string $haystack): bool
-	{
-		$length = strlen($needle);
-		if ($length === 0) {
-			return true;
-		}
-
-		return substr($haystack, -$length) === $needle;
-	}
-
 	public static function dateToString(DateTimeInterface $date): string
 	{
 		return $date->format(DateTimeInterface::ATOM);


### PR DESCRIPTION
PHP 8.0 tiene
`str_ends_with()` y `str_starts_with()`.

Pasar primero el PR #376 para evitar problemas.