### PR TITLE
Fix DbalTypesSearcher.php to use str_ends_with()

### DIFF
--- a/src/Mooc/Shared/Infrastructure/Doctrine/DbalTypesSearcher.php
+++ b/src/Mooc/Shared/Infrastructure/Doctrine/DbalTypesSearcher.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace CodelyTv\Mooc\Shared\Infrastructure\Doctrine;
 
-use CodelyTv\Shared\Domain\Utils;
-
 use function Lambdish\Phunctional\filter;
 use function Lambdish\Phunctional\map;
 use function Lambdish\Phunctional\reduce;

--- a/src/Mooc/Shared/Infrastructure/Doctrine/DbalTypesSearcher.php
+++ b/src/Mooc/Shared/Infrastructure/Doctrine/DbalTypesSearcher.php
@@ -51,7 +51,7 @@ final class DbalTypesSearcher
 	{
 		return static function (array $totalNamespaces, string $path) use ($contextName): array {
 			$possibleFiles = scandir($path);
-			$files = filter(static fn (string $file): bool => Utils::endsWith('Type.php', $file), $possibleFiles);
+			$files = filter(static fn (string $file): bool => str_ends_with($file, 'Type.php'), $possibleFiles);
 
 			$namespaces = map(
 				static function (string $file) use ($path, $contextName): string {


### PR DESCRIPTION
Para usar `str_ends_with()`

Mejor pasar este antes del otro PR que borra el `endsWith()`